### PR TITLE
Add project field to parameters and API requests

### DIFF
--- a/components/locations/ConfigScreen.tsx
+++ b/components/locations/ConfigScreen.tsx
@@ -16,6 +16,7 @@ export interface AppInstallationParameters {
   growthbookServerUrl?: string;
   growthbookAPIKey: string;
   datasourceId: string;
+  projectId?: string;
 }
 
 const ConfigScreen = () => {
@@ -220,6 +221,17 @@ const ConfigScreen = () => {
             onChange={(e) =>
               setParameters({ ...parameters, datasourceId: e.target.value })
             }
+          />
+          <FormControl.Label htmlFor="project-id">
+              Project Id (The optional project id that experiments and features are created under)
+          </FormControl.Label>
+          <TextInput
+              id="project-id"
+              name="project-id"
+              value={parameters.projectId}
+              onChange={(e) =>
+                  setParameters({ ...parameters, projectId: e.target.value || undefined })
+              }
           />
         </FormControl>
       </Form>

--- a/components/locations/Sidebar.tsx
+++ b/components/locations/Sidebar.tsx
@@ -13,9 +13,10 @@ import { GrowthbookAPIContext } from "../../contexts/GrowthbookAPIContext";
 import { ExperimentAPIResponse } from "../../types/experiment";
 import Link from "next/link";
 import { ContentTypesContext } from "contexts/ContentTypesContext";
+import {AppInstallationParameters} from "@/components/locations/ConfigScreen";
 
 const Sidebar = () => {
-  const sdk = useSDK<SidebarAppSDK>();
+  const sdk = useSDK<SidebarAppSDK<AppInstallationParameters>>();
 
   const { growthbookAPI: growthbookExperimentApi } =
     useContext(GrowthbookAPIContext);
@@ -140,6 +141,7 @@ ${entries
 
         const results = await growthbookExperimentApi?.createExperiment({
           datasourceId: sdk.parameters.installation.datasourceId,
+          project: sdk.parameters.installation.projectId,
           assignmentQueryId: "user_id",
           trackingKey,
           name: trimmedFormExperimentName,
@@ -168,6 +170,7 @@ ${entries
             owner: sdk.user.email,
             valueType: "string",
             defaultValue: "0",
+            project: sdk.parameters.installation.projectId,
             environments: {
               production: {
                 enabled: true,


### PR DESCRIPTION
It would be useful to be able to sort Contentful experiments into a specific project. 
This change should be backwards compatible and default to the old behaviour.